### PR TITLE
Removed warnings and errors

### DIFF
--- a/objc-xcode-warnings-errors/FISAppDelegate.m
+++ b/objc-xcode-warnings-errors/FISAppDelegate.m
@@ -9,40 +9,46 @@
     
     NSString *unused = @"This variable generates a warning because it is unused.";
     
-//    NSLog(@"%@", unused);
+    NSLog(@"%@", unused);
     
-//    NSInteger *i = 0;
-//    NSLog(@"i: %li", i);
+    NSInteger i = 12;
+    NSLog(@"i: %li", i);
     
-//    NSInteger x = i + 1;
-//    NSLog(@"x: %li", x);
+    NSInteger x = (i + 1);
+    NSLog(@"x: %li", x);
     
     NSLog(@"Anything after the return statement will not get executed.");
     
     return YES; // this line ends the method
     
     NSLog(@"Take note that this line doesn't print to the console.");
+
+NSString *message = @"Even though they don't belong here, the compiler won't actually complain about string literals or primitives defined outside of a method body (which is held by  curly braces {...} ), but...";
+
+NSInteger j = 0;
+BOOL itIsKnownKhaleesi = YES;
+
+NSLog(@"...any statements containing function calls, operations, or method calls will produce errors.");
+
+
+
+
+NSLog(@"%@", message);
+
+
+
+j++;
+
+itIsKnownKhaleesi = NO;
+
+
+    NSString *notlocal = @"Which means the variables above, while permitted, can't be used in the way that you intend."; //used the "fixit" option to remove "Using 'stringWithString:' with a literal is redundant" warning
+
+    
+NSLog(@"%@", notlocal); //added this line to remove the warning "Unused variable "notlocal"
+    
+    
+    
 }
-
-//NSString *message = @"Even though they don't belong here, the compiler won't actually complain about string literals or primitives defined outside of a method body (which is held by  curly braces {...} ), but...";
-
-//NSInteger j = 0;
-//BOOL itIsKnownKhaleesi = YES;
-
-//NSLog(@"...any statements containing function calls, operations, or method calls will produce errors.");
-
-
-
-
-//NSLog(@"%@", message);
-
-
-
-//j++;
-
-//itIsKnownKhaleesi = NO;
-
-
-//NSString *notLocal = [NSString stringWithString:@"Which means the variables above, while permitted, can't be used in the way that you intend."];
 
 @end


### PR DESCRIPTION
I added an additional line of code to remove an "Unused variable" warning (line 48) and used the fixit option to remove the "Using 'stringWithString:' with a literal is redundant" warning. Thanks!