### PR TITLE
getting familiar with error

### DIFF
--- a/objc-xcode-warnings-errors/FISAppDelegate.m
+++ b/objc-xcode-warnings-errors/FISAppDelegate.m
@@ -9,40 +9,44 @@
     
     NSString *unused = @"This variable generates a warning because it is unused.";
     
-//    NSLog(@"%@", unused);
+    NSLog(@"%@", unused);
     
-//    NSInteger *i = 0;
-//    NSLog(@"i: %li", i);
+    NSInteger i = 12;
+    NSLog(@"i: %li", i);
     
-//    NSInteger x = i + 1;
-//    NSLog(@"x: %li", x);
+    NSInteger x = i + 1;
+    NSLog(@"x: %li", x);
     
     NSLog(@"Anything after the return statement will not get executed.");
     
     return YES; // this line ends the method
     
     NSLog(@"Take note that this line doesn't print to the console.");
+    
+    NSString *message = @"Even though they don't belong here, the compiler won't actually complain about string literals or primitives defined outside of a method body (which is held by  curly braces {...} ), but...";
+    
+    NSInteger j = 0;
+    BOOL itIsKnownKhaleesi = YES;
+    
+    NSLog(@"...any statements containing function calls, operations, or method calls will produce errors.");
+    
+    
+    
+    
+    NSLog(@"%@", message);
+    
+    
+    
+    j++;
+    
+    itIsKnownKhaleesi = NO;
+    
+    
+    NSString *notLocal = @"Which means the variables above, while permitted, can't be used in the way that you intend.";
+    NSLog(@"%@", notLocal);
+    
 }
 
-//NSString *message = @"Even though they don't belong here, the compiler won't actually complain about string literals or primitives defined outside of a method body (which is held by  curly braces {...} ), but...";
 
-//NSInteger j = 0;
-//BOOL itIsKnownKhaleesi = YES;
-
-//NSLog(@"...any statements containing function calls, operations, or method calls will produce errors.");
-
-
-
-
-//NSLog(@"%@", message);
-
-
-
-//j++;
-
-//itIsKnownKhaleesi = NO;
-
-
-//NSString *notLocal = [NSString stringWithString:@"Which means the variables above, while permitted, can't be used in the way that you intend."];
 
 @end


### PR DESCRIPTION
Line 45/46 was confusing. (NSString *notLocal)

There were 2 warnings after I moved the statement within the method. 

One was straight forward (the variable wasn't being used)
The other was syntax related - which i didn't understand... It looked like it was trying to define something else within the square brackets.

So I just redefined the string without the square brackets and NSLog'd it.
